### PR TITLE
Add failed test case for selection-set-depth's suggestion feature

### DIFF
--- a/packages/plugin/tests/selection-set-depth.spec.ts
+++ b/packages/plugin/tests/selection-set-depth.spec.ts
@@ -7,6 +7,19 @@ const WITH_SIBLINGS = {
   },
 };
 
+const WITH_SIBLINGS_DEEP = {
+  parserOptions: <ParserOptions>{
+    operations: `
+      fragment AlbumFields on Album {
+        id
+        modifier {
+          date
+        }
+      }
+    `,
+  },
+};
+
 const ruleTester = new GraphQLRuleTester();
 
 ruleTester.runGraphQLTests<[SelectionSetDepthRuleConfig]>('selection-set-depth', rule, {
@@ -90,6 +103,21 @@ ruleTester.runGraphQLTests<[SelectionSetDepthRuleConfig]>('selection-set-depth',
               ... on Album {
                 id
               }
+            }
+          }
+        }
+      `,
+    },
+    {
+      name: 'suggestions should work with error depth in inline fragments',
+      ...WITH_SIBLINGS_DEEP,
+      options: [{ maxDepth: 2 }],
+      errors: [{ message: "'' exceeds maximum operation depth of 2" }],
+      code: /* GraphQL */ `
+        query {
+          viewer {
+            albums {
+              ...AlbumFields
             }
           }
         }


### PR DESCRIPTION
After https://github.com/B2o5T/graphql-eslint/pull/971, for
`selection-set-depth` rules, if the depth error occures in a different
file than source file (e.g. in an imported fragment file), JavaScript
exception might thrown because it can not find the token node in source
file.